### PR TITLE
doc/conmmunity: Add infomation-tips based on lfxSpeed

### DIFF
--- a/docs/03.社区作品/06.基于lfxSpeed制作的infomation-tips.md
+++ b/docs/03.社区作品/06.基于lfxSpeed制作的infomation-tips.md
@@ -1,0 +1,16 @@
+# infomation-tips
+
+> 在屏幕上显示系统运行信息
+
+## 截图
+
+![](https://github.com/zinface/infomation-tips/blob/master/screenshot/screenshot.png?raw=true)
+![](https://github.com/zinface/infomation-tips/blob/master/screenshot/screenshot1.png?raw=true) 
+
+## 灵感来源
+
+* [lfxSpeed](https://github.com/xmuli/lfxSpeed): 在开发之前阅读了 `lfxSpeed` 项目的开源代码，发现dde-dock栏下的`lfxSpeed`插件虽然可用，但置于屏幕上设置为全局top及穿透反而可能更好(并且支持以`颜色划分使用率`)。 
+
+## 项目地址
+
+* [infomation-tips](https://github.com/zinface/infomation-tips)


### PR DESCRIPTION
# infomation-tips

> 在屏幕上显示系统运行信息

## 截图

![](https://github.com/zinface/infomation-tips/blob/master/screenshot/screenshot.png?raw=true)
![](https://github.com/zinface/infomation-tips/blob/master/screenshot/screenshot1.png?raw=true) 

## 灵感来源

* [lfxSpeed](https://github.com/xmuli/lfxSpeed): 在开发之前阅读了 `lfxSpeed` 项目的开源代码，发现dde-dock栏下的`lfxSpeed`插件虽然可用，但置于屏幕上设置为全局top及穿透反而可能更好(并且支持以`颜色划分使用率`)。 

## 项目地址

* [infomation-tips](https://github.com/zinface/infomation-tips)